### PR TITLE
feat: add pi-opensync-plugin community plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Cloud-synced dashboards that track session activity, tool usage, and token spend
 | droid-sync             | Sync Factory Droid sessions (community built) | [GitHub](https://github.com/yemyat/droid-sync-plugin) / [npm](https://www.npmjs.com/package/droid-sync)                       |
 | codex-sync             | Sync Codex CLI sessions                       | [GitHub](https://github.com/waynesutton/codex-sync-plugin) / [npm](https://www.npmjs.com/package/codex-sync)                  |
 | cursor-opensync-plugin | Sync Cursor sessions                          | [GitHub](https://github.com/waynesutton/cursor-cli-sync-plugin) / [npm](https://www.npmjs.com/package/cursor-opensync-plugin) |
+| pi-opensync-plugin     | Sync Pi coding agent sessions                 | [GitHub](https://github.com/joshuadavidthomas/pi-opensync-plugin) / [npm](https://www.npmjs.com/package/pi-opensync-plugin)   |
 
 ## Features
 
@@ -84,6 +85,16 @@ cursor-sync login
 ```
 
 [Cursor plugin docs](https://www.opensync.dev/docs#cursor-plugin)
+
+**For Pi:**
+
+```bash
+npm install -g pi-opensync-plugin
+```
+
+Then run `/opensync:config` in pi to configure the extension.
+
+[Pi plugin docs](https://www.opensync.dev/docs#pi-plugin)
 
 ## Self hosting
 

--- a/src/lib/source.ts
+++ b/src/lib/source.ts
@@ -5,7 +5,8 @@ export type SourceType =
   | "opencode"
   | "codex-cli"
   | "cursor-sync"
-  | "cursor"; // Alias for cursor-sync (legacy data)
+  | "cursor" // Alias for cursor-sync (legacy data)
+  | "pi";
 
 /**
  * Get display label for a source
@@ -26,7 +27,9 @@ export function getSourceLabel(
           ? "CX"
           : s === "cursor-sync" || s === "cursor"
             ? "CR"
-            : "OC";
+            : s === "pi"
+              ? "PI"
+              : "OC";
   }
   return s === "claude-code"
     ? "Claude Code"
@@ -36,7 +39,9 @@ export function getSourceLabel(
         ? "Codex CLI"
         : s === "cursor-sync" || s === "cursor"
           ? "Cursor"
-          : "OpenCode";
+          : s === "pi"
+            ? "Pi"
+            : "OpenCode";
 }
 
 /**
@@ -73,6 +78,11 @@ export function getSourceColorClass(
         ? "bg-violet-500/20 text-violet-400"
         : "bg-violet-100 text-violet-700";
     }
+    if (s === "pi") {
+      return isDark
+        ? "bg-[#f97316]/20 text-[#f97316]"
+        : "bg-[#f97316]/10 text-[#ea580c]";
+    }
     return isDark
       ? "bg-blue-500/20 text-blue-400"
       : "bg-blue-100 text-blue-700";
@@ -83,5 +93,6 @@ export function getSourceColorClass(
   if (s === "factory-droid") return "bg-orange-500/15 text-orange-400";
   if (s === "codex-cli") return "bg-purple-500/15 text-purple-400";
   if (s === "cursor-sync" || s === "cursor") return "bg-violet-500/15 text-violet-400";
+  if (s === "pi") return "bg-[#f97316]/15 text-[#f97316]";
   return "bg-blue-500/15 text-blue-400";
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -66,6 +66,7 @@ const AI_AGENTS_MAP: Record<string, string> = {
   "cursor-sync": "Cursor",
   "cursor": "Cursor", // Alias for legacy data
   "codex-cli": "Codex CLI",
+  "pi": "Pi",
   "continue": "Continue",
   "amp": "Amp",
   "aider": "Aider",
@@ -643,6 +644,55 @@ function SetupBanner({ theme, onDismiss }: { theme: "dark" | "tan"; onDismiss: (
                   className={cn(
                     "flex items-center gap-1 text-[10px] transition-colors",
                     isDark ? "text-orange-400 hover:text-orange-300" : "text-[#EB5601] hover:opacity-80"
+                  )}
+                >
+                  <ExternalLink className="h-3 w-3" />
+                  npm
+                </a>
+              </div>
+            </div>
+            
+            {/* Pi Plugin */}
+            <div className={cn(
+              "rounded-lg border p-3",
+              isDark ? "bg-zinc-900/50 border-zinc-700" : "bg-white border-[#e5e0d8]"
+            )}>
+              <div className="flex items-center gap-2 mb-2">
+                <div className="w-5 h-5 rounded bg-[#f97316]/15 flex items-center justify-center">
+                  <span className="text-[10px] font-medium text-[#f97316]">PI</span>
+                </div>
+                <span className={cn("text-xs font-medium", t.textSecondary)}>pi-opensync-plugin</span>
+              </div>
+              <p className={cn("text-[11px] mb-2", t.textDim)}>
+                Sync your Pi coding agent sessions to the dashboard.
+              </p>
+              <div className={cn(
+                "rounded px-2 py-1.5 text-[11px] font-mono mb-2",
+                isDark ? "bg-zinc-800" : "bg-[#f5f3f0]",
+                t.textMuted
+              )}>
+                npm install -g pi-opensync-plugin
+              </div>
+              <div className="flex items-center gap-2">
+                <a
+                  href="https://github.com/joshuadavidthomas/pi-opensync-plugin"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={cn(
+                    "flex items-center gap-1 text-[10px] transition-colors",
+                    isDark ? "text-[#f97316] hover:text-[#fb923c]" : "text-[#EB5601] hover:opacity-80"
+                  )}
+                >
+                  <Github className="h-3 w-3" />
+                  GitHub
+                </a>
+                <a
+                  href="https://www.npmjs.com/package/pi-opensync-plugin"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={cn(
+                    "flex items-center gap-1 text-[10px] transition-colors",
+                    isDark ? "text-[#f97316] hover:text-[#fb923c]" : "text-[#EB5601] hover:opacity-80"
                   )}
                 >
                   <ExternalLink className="h-3 w-3" />

--- a/src/pages/Evals.tsx
+++ b/src/pages/Evals.tsx
@@ -38,6 +38,7 @@ const AI_AGENTS_MAP: Record<string, string> = {
   "factory-droid": "Factory Droid",
   "cursor-sync": "Cursor",
   cursor: "Cursor",
+  pi: "Pi",
   "codex-cli": "Codex CLI",
   continue: "Continue",
   amp: "Amp",

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -162,6 +162,7 @@ function getSourceDisplayName(source: string): string {
     codex: "Codex",
     "codex-cli": "Codex CLI",
     amp: "Amp",
+    pi: "Pi",
   };
   return names[source] || source;
 }
@@ -1005,6 +1006,30 @@ export function LoginPage() {
                       Cursor
                     </span>
                   </a>
+
+                  {/* Pi */}
+                  <a
+                    href="https://www.npmjs.com/package/pi-opensync-plugin"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex flex-col items-center gap-1.5 transition-opacity hover:opacity-70"
+                    title="Pi"
+                  >
+                    <svg
+                      className={`h-8 w-8 ${isDark ? "text-zinc-300" : "text-[#1a1a1a]"}`}
+                      viewBox="155 155 490 490"
+                      fill="currentColor"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path fillRule="evenodd" d="M165.29 165.29 H517.36 V400 H400 V517.36 H282.65 V634.72 H165.29 Z M282.65 282.65 V400 H400 V282.65 Z" />
+                      <path d="M517.36 400 H634.72 V634.72 H517.36 Z" />
+                    </svg>
+                    <span
+                      className={`text-[10px] ${isDark ? "text-zinc-500" : "text-[#8b7355]"}`}
+                    >
+                      Pi
+                    </span>
+                  </a>
                 </div>
               </div>
 
@@ -1193,6 +1218,48 @@ export function LoginPage() {
                     >
                       npm
                     </span>
+                  </a>
+
+                  {/* Pi Sync - Community */}
+                  <a
+                    href="https://www.npmjs.com/package/pi-opensync-plugin"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`group flex items-center justify-between rounded-md border px-3 py-2 transition-colors ${
+                      isDark
+                        ? "border-zinc-800 bg-[#0E0E0E] hover:border-zinc-700"
+                        : "border-[#e6e4e1] bg-[#faf8f5] hover:border-[#8b7355]"
+                    }`}
+                  >
+                    <span
+                      className={`font-mono text-xs ${
+                        isDark
+                          ? "text-zinc-100 group-hover:text-zinc-300"
+                          : "text-[#6b6b6b] group-hover:text-[#1a1a1a]"
+                      }`}
+                    >
+                      pi-opensync-plugin
+                    </span>
+                    <div className="flex items-center gap-1.5">
+                      <span
+                        className={`rounded px-1.5 py-0.5 text-[10px] ${
+                          isDark
+                            ? "bg-emerald-900/30 text-emerald-400"
+                            : "bg-emerald-100 text-emerald-700"
+                        }`}
+                      >
+                        community
+                      </span>
+                      <span
+                        className={`rounded px-1.5 py-0.5 text-[10px] ${
+                          isDark
+                            ? "bg-zinc-800 text-zinc-600"
+                            : "bg-[#ebe9e6] text-[#8b7355]"
+                        }`}
+                      >
+                        npm
+                      </span>
+                    </div>
                   </a>
                 </div>
               </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -87,6 +87,13 @@ const AI_AGENTS: AIAgent[] = [
     url: "https://www.npmjs.com/package/codex-sync",
   },
   {
+    id: "pi",
+    name: "Pi",
+    status: "community",
+    defaultEnabled: false,
+    url: "https://www.npmjs.com/package/pi-opensync-plugin",
+  },
+  {
     id: "continue",
     name: "Continue",
     status: "planned",
@@ -473,6 +480,9 @@ export function SettingsPage() {
                       <p className={cn("mt-2", t.textDim)}># For Cursor</p>
                       <p>npm install -g cursor-opensync-plugin</p>
                       <p>cursor-sync login</p>
+                      <p className={cn("mt-2", t.textDim)}># For Pi</p>
+                      <p>npm install -g pi-opensync-plugin</p>
+                      <p># Then run /opensync:config in pi</p>
                     </div>
                   </div>
 
@@ -606,6 +616,33 @@ export function SettingsPage() {
                       </span>{" "}
                       <a
                         href="https://github.com/waynesutton/cursor-cli-sync-plugin"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={cn("text-xs", t.textDim, "hover:underline")}
+                      >
+                        (GitHub)
+                      </a>
+                    </p>
+                    <p>
+                      <a
+                        href="https://www.npmjs.com/package/pi-opensync-plugin"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={cn(
+                          "inline-flex items-center gap-1 font-medium",
+                          theme === "dark"
+                            ? "text-blue-400 hover:text-blue-300"
+                            : "text-[#EB5601] hover:text-[#d14a01]",
+                        )}
+                      >
+                        pi-opensync-plugin
+                        <ExternalLink className="h-3 w-3" />
+                      </a>{" "}
+                      <span className={t.textDim}>
+                        Sync your Pi sessions
+                      </span>{" "}
+                      <a
+                        href="https://github.com/joshuadavidthomas/pi-opensync-plugin"
                         target="_blank"
                         rel="noopener noreferrer"
                         className={cn("text-xs", t.textDim, "hover:underline")}


### PR DESCRIPTION
Add support for pi-opensync-plugin, a community-built plugin that syncs Pi coding agent sessions to OpenSync.

- Add "pi" source type with orange PI badge
- Add Pi to Login page "Syncs with" section
- Add Pi to Settings AI Agents with community status
- Add Pi plugin card to Dashboard setup banner
- Add Pi source label mapping to Evals page
- Update README ecosystem table and install instructions